### PR TITLE
[doc] Removing useless flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install with [npm](https://www.npmjs.com/package/aframe-react) or
 
 ```
 npm install --save aframe aframe-react react react-dom
-yarn add --save aframe aframe-react react react-dom
+yarn add aframe aframe-react react react-dom
 ```
 
 ## Example


### PR DESCRIPTION
Yarn do not need a --save flag for saving a dependency with "add". It's the default behavior.